### PR TITLE
Add sponsor metadata and funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: RDM3DC

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ keywords:
   - Bell
   - analogue
   - donation
+  - sponsor
 authors:
   - name: RDM3DC
 repository-code: "https://github.com/RDM3DC/RTS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = { text = "MIT" }
 authors = [
   { name = "RDM3DC", email = "rdm3dc@example.com" }
 ]
-keywords = ["superconductivity", "hydrides", "ARP", "materials", "Bell", "analogue", "donation"]
+keywords = ["superconductivity", "hydrides", "ARP", "materials", "Bell", "analogue", "donation", "sponsor"]
 dependencies = [
   "numpy>=1.22",
   "pandas>=2.0",


### PR DESCRIPTION
## Summary
- add `sponsor` keyword to project metadata
- configure GitHub Sponsors via funding file

## Testing
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdfd18dc8832fb6dff9d0287e2dc3